### PR TITLE
Big change for template docs page

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -98,7 +98,7 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula 
 Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.
 
 ```
-Adding more posts entries:
+Adding one more post:
 
 `/content/posts/my-second-post.md`:
 
@@ -120,7 +120,7 @@ Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus
 
 ### Linking content to template
 
-Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem) added to config (`gridsome.config.js`) and [@gridsome/transformer-remark plugin](https://gridsome.org/plugins/@gridsome/transformer-remark)
+Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem) added to config (`gridsome.config.js`). We also use [@gridsome/transformer-remark plugin](https://gridsome.org/plugins/@gridsome/transformer-remark).
 
 ```javascript
 module.exports = {

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -120,7 +120,7 @@ Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus
 
 ### Linking content to template
 
-Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem) added to config (`gridsome.config.js`).
+Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem) added to config (`gridsome.config.js`) and [@gridsome/transformer-remark plugin](https://gridsome.org/plugins/@gridsome/transformer-remark)
 
 ```javascript
 module.exports = {
@@ -136,7 +136,18 @@ module.exports = {
     {
       // another data source
     },
-  ]
+  ],
+  transformers: {
+    //Add markdown support to all file-system sources
+    remark: {
+      externalLinksTarget: '_blank',
+      externalLinksRel: ['nofollow', 'noopener', 'noreferrer'],
+      anchorClassName: 'icon icon-link',
+      plugins: [
+        '@gridsome/remark-prismjs'
+      ]
+    }
+  },
 }
 ```
 Learn more about [Use data source plugins](/docs/fetching-data#use-data-source-plugins)

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -128,8 +128,8 @@ module.exports = {
     {
       use: '@gridsome/source-filesystem',
       options: {
-        typeName: 'Post', /* vue file in src/templates must match the GraphQL typeName to have a template for it.*/
-        path: 'content/posts/*.md', /* Where to look for files. Should be a glob path. */
+        typeName: 'Post', /* vue file in src/templates must match the GraphQL typeName to have a template for it */
+        path: 'content/posts/*.md', /* Where to look for files. Should be a glob path */
         route: '/:slug', /* Define a dynamic route */
       }
     },


### PR DESCRIPTION
More readable (Before it was very hard to understand the docs about this issue).

Keep in mind I am new to gridsome (Fell free to made changes). Anyway the connection between of
` data: "hello" ` 
and inside html:
` <h1>{{ data }}</h1> `
output ==> "hello"
Is very helpful - Otherwise, it's very hard to understand the CMS - so this is my main idea/goal her. 

## 1. simple template
For example - in the current example the template use this:
https://gridsome.org/docs/layouts#passing-props-to-layouts
But, this is a *separate* topic/idea = harder to understand.

In my opinion, the basic template should be "very clean" (Without props/components and so on). 

## 2. Current docs missing the data files
Md for example. Fix

## 3. Current docs missing the idea of source-filesystem setting
Fix

## missing
How to add custom button for each blog list (For collection lists of posts for example)